### PR TITLE
Set the SSSL context on connection creation

### DIFF
--- a/python/create_client/create_client.py
+++ b/python/create_client/create_client.py
@@ -10,6 +10,7 @@
 
 import json
 import time
+import ssl
 
 # Coming from the vendors folder
 import websocket
@@ -120,10 +121,13 @@ class CreateClient(object):
                     self._connection = None
 
             if not self._connection:
+                ssl_defaults = ssl.get_default_verify_paths()
+
                 self._connection = websocket.create_connection(
                     "wss://shotgunlocalhost.com:{0}".format(
                         self.shotgun_create_websocket_port
-                    )
+                    ),
+                    sslopt={"ca_certs": ssl_defaults.cafile},
                 )
 
                 self._do_websocketserver_handshake()


### PR DESCRIPTION
JIRA: VMR-2289

On some DCCs, the CreateClient object raise an exception at the connection creation.

`Failed to get a valid websocket connection: cafile, capath and cadata cannot be all omitted`.

A straightforward solution is to always set it to the python default SSL CA file.