### PR TITLE
SG-23055 - Use the new SG Create location

### DIFF
--- a/python/create_client/create_utils.py
+++ b/python/create_client/create_utils.py
@@ -26,9 +26,9 @@ CREATE_DEFAULT_LOCATION = ShotgunPath.from_shotgun_dict(
                 # This is why we use get with a dummy default value.
                 os.environ.get("ProgramFiles", "%ProgramFiles%"),
                 "Autodesk",
-                "Shotgun Create",
+                "ShotGrid Create",
                 "bin",
-                "ShotgunCreate.exe",
+                "ShotGridCreate.exe",
             )
         ),
         "mac_path": os.path.abspath(
@@ -36,15 +36,15 @@ CREATE_DEFAULT_LOCATION = ShotgunPath.from_shotgun_dict(
                 os.sep,
                 "Applications",
                 "Autodesk",
-                "Shotgun Create.app",
+                "ShotGrid Create.app",
                 "Contents",
                 "MacOS",
-                "Shotgun Create",
+                "ShotGrid Create",
             )
         ),
         "linux_path": os.path.abspath(
             os.path.join(
-                os.sep, "opt", "Autodesk", "ShotgunCreate", "bin", "ShotgunCreate"
+                os.sep, "opt", "Autodesk", "ShotGridCreate", "bin", "ShotGridCreate"
             )
         ),
     }


### PR DESCRIPTION
SG Create's install path changed with the renaming of Shotgun to ShotGrid. This is fixing a bug where the Send for Review feature wouldn't work because this framework could not locate ShotGrid Create.