### PR TITLE
Remove Python 2 code

### DIFF
--- a/create_client.py
+++ b/create_client.py
@@ -10,7 +10,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from __future__ import print_function, absolute_import
 import sgtk
 import json
 

--- a/python/create_client/create_client.py
+++ b/python/create_client/create_client.py
@@ -63,7 +63,7 @@ class CreateClient(object):
         :param int port_override: The port number used for the connection. If not set,
                 the value from Shotgun preferences or a default value is used
         """
-        super(CreateClient, self).__init__()
+        super().__init__()
 
         self._connection = None
         self._server_id = None


### PR DESCRIPTION
## What's new?

- Minor changes to remove Python 2 specific syntax
- README badges are updated in #27
- Six is entirely removed on #26