### PR TITLE
SG-33057 update pre commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,27 @@
+# Copyright (c) 2024 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+default_language_version:
+    python: python3
+
 # Styles the code properly
 # Exclude the UI files, as they are auto-generated.
 exclude: "^Vendors"
+
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v5.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -22,8 +35,7 @@ repos:
     # Removes trailing whitespaces.
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/python/create_client/create_utils.py
+++ b/python/create_client/create_utils.py
@@ -78,9 +78,9 @@ def launch_shotgun_create(sg_connection=None):
 
         # Set the current credentials so create starts in the right environment
         create_env["SHOTGUN_CREATE_AUTHENTICATION_SITE"] = sg_connection.base_url
-        create_env[
-            "SHOTGUN_CREATE_AUTHENTICATION_SESSION"
-        ] = sg_connection.get_session_token()
+        create_env["SHOTGUN_CREATE_AUTHENTICATION_SESSION"] = (
+            sg_connection.get_session_token()
+        )
 
         # Unset values that might cause Shotgun Create to not start
         # correctly. Some, originally set by Shotgun Desktop, might


### PR DESCRIPTION
Cleanup and update `.pre-commit-config.yaml` file:
- Update pre-commit-hooks to version `v5.0.0`
- Update black hook to version `25.1.0`
- Update black hook URL
- Use global `default_language_version` instead of individuals `language_version`

These changes are optional considering shotgunsoftware/tk-ci-tools#58. But we might want to cleanup/update the `.pre-commit-config.yaml` file every once in a while.