### PR TITLE
SG-42049: Update README badges

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ exclude: "^Vendors"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -36,6 +36,6 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
     - id: black

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Frameworks/tk-framework-desktopclient?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=75&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
 
 ## Documentation
 This repository is a part of the Flow Production Tracking Toolkit.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
-[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
+[![Supported VFX Platform: CY2022 - CY2026](https://img.shields.io/badge/VFX_Reference_Platform-CY2022_|_CY2023_|_CY2024_|_CY2025_|_CY2026-blue)](http://www.vfxplatform.com/ "Supported VFX Reference Platform versions")
+[![Supported Python versions: 3.9, 3.10, 3.11, 3.13](https://img.shields.io/badge/Python-3.9_|_3.10_|_3.11_|_3.13-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Frameworks/tk-framework-desktopclient?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=75&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 


### PR DESCRIPTION
Updates README badges:
- Removed deprecated HoundCI badge
- Updated VFX Platform to include CY2026 support
- Updated Python versions to include 3.13
- Updated pre-commit hooks (v5.0.0 → v6.0.0, black 25.1.0 → 26.1.0)


Related SG-42049 PRs:
- shotgunsoftware/tk-aftereffects#63
- shotgunsoftware/tk-core#1084
- shotgunsoftware/tk-framework-desktopclient#36
- shotgunsoftware/tk-framework-qtwidgets#181
- shotgunsoftware/tk-framework-shotgunutils#177
- shotgunsoftware/tk-framework-widget#31
- shotgunsoftware/tk-multi-about#36
- shotgunsoftware/tk-multi-breakdown#45
- shotgunsoftware/tk-multi-demo#48
- shotgunsoftware/tk-multi-launchapp#111
- shotgunsoftware/tk-multi-loader2#135
- shotgunsoftware/tk-multi-publish2#211
- shotgunsoftware/tk-multi-pythonconsole#44
- shotgunsoftware/tk-multi-reviewsubmission#51
- shotgunsoftware/tk-multi-screeningroom#26
- shotgunsoftware/tk-multi-snapshot#50
- shotgunsoftware/tk-multi-workfiles2#170
- shotgunsoftware/tk-shell#38